### PR TITLE
fix(docs): update chip map for gfm pandoc formatter

### DIFF
--- a/docs/chip_map.md
+++ b/docs/chip_map.md
@@ -2,12 +2,18 @@
 
 ![Full chip map](images/shuttle_map.svg){width=12cm}
 
+```{=latex}
 \pagebreak
+```
 
 ![GDS render](images/full_gds.png){width=12cm}
 
+```{=latex}
 \pagebreak
+```
 
 ![Logic density (local interconnect layer)](images/logic_density.png){width=12cm}
 
+```{=latex}
 \pagebreak
+```


### PR DESCRIPTION
TinyTapeout/tt-support-tools#92 breaks implicit raw latex support in the datasheet, so we are making it explicit.